### PR TITLE
SiteFilterBehavior fixed

### DIFF
--- a/Model/Behavior/SiteFilterBehavior.php
+++ b/Model/Behavior/SiteFilterBehavior.php
@@ -36,7 +36,12 @@ class SiteFilterBehavior extends ModelBehavior {
 		}
 		$this->_setupRelationships($model, $this->settings[$model->alias]);
 		$site = Sites::currentSite();
-		$sites = array_unique(array(Sites::ALL_SITES, $site['Site']['id']));
+
+		$sites = array(Sites::ALL_SITES);
+
+		if ($site) {
+			array_unique(array(Sites::ALL_SITES, $site['Site']['id']));
+		}
 
 		$setting = Set::merge(
 			array('relationship' => array(), 'joins' => array()),

--- a/Model/Behavior/SiteFilterBehavior.php
+++ b/Model/Behavior/SiteFilterBehavior.php
@@ -40,7 +40,7 @@ class SiteFilterBehavior extends ModelBehavior {
 		$sites = array(Sites::ALL_SITES);
 
 		if ($site) {
-			array_unique(array(Sites::ALL_SITES, $site['Site']['id']));
+			$sites = array_unique(array(Sites::ALL_SITES, $site['Site']['id']));
 		}
 
 		$setting = Set::merge(


### PR DESCRIPTION
There was a trying to access a non existent index due to a empty
sites table when it tries to get the currentSite. I've fixed it with a
simple check on the currentSite method returning.
